### PR TITLE
v0.2.0

### DIFF
--- a/docs/custom_components.md
+++ b/docs/custom_components.md
@@ -749,6 +749,60 @@ class CustomSegmentationAdapter(torch.nn.Module, SegmentationModelProtocol):
         return self.logits(x)
 ```
 
+## Custom Adapters: Multiple and Direct Passing
+
+### Registering Multiple Custom Adapters
+
+You can register multiple custom adapters with names like `custom_myadapter`:
+
+```python
+from segmentation_robustness_framework.adapters import CustomAdapter
+from segmentation_robustness_framework.adapters.registry import register_adapter
+
+@register_adapter("custom_myadapter")
+class MyCustomAdapter(CustomAdapter):
+    pass
+
+@register_adapter("custom_other")
+class OtherCustomAdapter(CustomAdapter):
+    pass
+```
+
+To use a specific adapter, set `model_type` to the registered name:
+
+```python
+loader = UniversalModelLoader()
+model = loader.load_model(
+    model_type="custom_myadapter",
+    model_config={...}
+)
+```
+
+### Passing Adapter Class Directly
+
+You can also pass an adapter class directly to `UniversalModelLoader.load_model`:
+
+```python
+model = loader.load_model(
+    model_type="custom",
+    model_config={...},
+    adapter_cls=MyCustomAdapter
+)
+```
+
+If both a registered adapter and an `adapter_cls` are provided, the `adapter_cls` takes precedence.
+
+## Loader Weights: Torchvision, SMP, HuggingFace
+
+- **Torchvision**: Use `weights="default"` or `weights="DEFAULT"` (case-insensitive) to load default pretrained weights.
+- **SMP**: Use `weight_type="encoder"` in `load_weights` to load only encoder weights.
+- **HuggingFace**: Use `weight_type="encoder"` in `load_weights` to load only encoder weights.
+
+## HuggingFace Loader: Expanded Model/Task Support
+
+- You can specify a custom model class in the config with `model_cls` (string or class).
+- Supported tasks: `semantic_segmentation`, `instance_segmentation`, `panoptic_segmentation`, `image_segmentation`.
+
 ## 🔗 Integration Examples
 
 ### Complete Custom Component Integration

--- a/docs/reference/model_loaders.md
+++ b/docs/reference/model_loaders.md
@@ -12,8 +12,31 @@ The framework includes the following model loader classes:
 
 Each loader implements a consistent interface with the following main methods:
 
-- `load_model(model_config: dict) -> nn.Module`: Instantiates a model according to the provided configuration dictionary.
+- `load_model(model_config: dict, adapter_cls: Optional[type] = None, ...) -> nn.Module`: Instantiates a model according to the provided configuration dictionary. For the universal loader, you can now pass an adapter class directly via `adapter_cls` (takes precedence over registry).
 - `load_weights(model: nn.Module, weights_path: str, weight_type: str = "full") -> nn.Module`: Loads weights into the model. The `weight_type` argument can be `"full"` (entire model) or `"encoder"` (encoder-only weights, if supported).
+
+## UniversalModelLoader: Custom Adapters and Direct Adapter Passing
+
+- You can register multiple custom adapters with names like `custom_myadapter` and use them by specifying `model_type="custom_myadapter"`.
+- You can also pass an adapter class directly to `load_model` via the `adapter_cls` argument, e.g.:
+
+```python
+model = loader.load_model("custom", config, adapter_cls=MyCustomAdapter)
+```
+
+## TorchvisionModelLoader: Weights Handling
+
+- The `weights` argument now accepts both `"default"` and `"DEFAULT"` (case-insensitive) to use the default pretrained weights.
+
+## SMPModelLoader: Encoder Weights
+
+- You can load only encoder weights by passing `weight_type="encoder"` to `load_weights`.
+
+## HuggingFaceModelLoader: Expanded Support
+
+- Supports tasks: `semantic_segmentation`, `instance_segmentation`, `panoptic_segmentation`, `image_segmentation`.
+- You can specify a custom model class in the config with `model_cls` (string or class).
+- You can load only encoder weights by passing `weight_type="encoder"` to `load_weights`.
 
 Refer to the API documentation below for detailed class and method signatures, configuration options, and usage examples for each loader.
 

--- a/docs/universal_configuration_guide.md
+++ b/docs/universal_configuration_guide.md
@@ -470,6 +470,26 @@ dataset_loader = UniversalDatasetLoader()
 dataset = dataset_loader.load_dataset(config.dataset.model_dump())
 ```
 
+## UniversalModelLoader: Custom Adapters and Direct Adapter Passing
+
+- Register multiple custom adapters with names like `custom_myadapter` and use them by specifying `model_type="custom_myadapter"`.
+- Pass an adapter class directly to `load_model` via the `adapter_cls` argument (takes precedence over registry):
+
+```python
+model = loader.load_model("custom", config, adapter_cls=MyCustomAdapter)
+```
+
+## Loader Weights: Torchvision, SMP, HuggingFace
+
+- **Torchvision**: Use `weights="default"` or `weights="DEFAULT"` (case-insensitive) to load default pretrained weights.
+- **SMP**: Use `weight_type="encoder"` in `load_weights` to load only encoder weights.
+- **HuggingFace**: Use `weight_type="encoder"` in `load_weights` to load only encoder weights.
+
+## HuggingFace Loader: Expanded Model/Task Support
+
+- Supported tasks: `semantic_segmentation`, `instance_segmentation`, `panoptic_segmentation`, `image_segmentation`.
+- Specify a custom model class in the config with `model_cls` (string or class).
+
 ## Best Practices
 
 ### 1. Module Organization

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "segmentation-robustness-framework"
-version = "0.1.3"
+version = "0.2.0"
 description = "Segmentation Robustness Framework - a powerful toolkit for evaluating the robustness of semantic segmentation models against adversarial attacks."
 license = "MIT"
 authors = ["Egor Vorobyev <voro6yov.egor@gmail.com>"]

--- a/segmentation_robustness_framework/__version__.py
+++ b/segmentation_robustness_framework/__version__.py
@@ -1,3 +1,3 @@
-VERSION = (0, 1, 3)
+VERSION = (0, 2, 0)
 
 __version__ = ".".join(map(str, VERSION))

--- a/segmentation_robustness_framework/config/model.py
+++ b/segmentation_robustness_framework/config/model.py
@@ -5,6 +5,16 @@ from pydantic import BaseModel, Field
 
 
 class TorchvisionConfig(BaseModel):
+    """Configuration for Torchvision segmentation models.
+
+    Attributes:
+        type (Literal["torchvision"]): Model type identifier.
+        name (str): Model name (e.g., 'deeplabv3_resnet50').
+        num_classes (int, optional): Number of output classes. Defaults to 21.
+        weights (Any, optional): Pretrained weights identifier or enum. Defaults to None.
+        device (str, optional): Device to use. Defaults to 'cpu'.
+    """
+
     type: Literal["torchvision"]
     name: str
     num_classes: Optional[int] = 21
@@ -13,6 +23,20 @@ class TorchvisionConfig(BaseModel):
 
 
 class SMPConfig(BaseModel):
+    """Configuration for segmentation_models_pytorch (SMP) models.
+
+    Attributes:
+        type (Literal["smp"]): Model type identifier.
+        architecture (str): Model architecture (e.g., 'unet').
+        encoder_name (str, optional): Encoder name. Defaults to 'resnet50'.
+        encoder_weights (str, optional): Encoder weights. Defaults to 'imagenet'.
+        classes (int, optional): Number of output classes. Defaults to 1.
+        activation (str, optional): Activation function. Defaults to None.
+        weights_path (str | Path, optional): Path to weights file. Defaults to None.
+        checkpoint (str, optional): Pretrained checkpoint identifier. Defaults to None.
+        device (str, optional): Device to use. Defaults to 'cpu'.
+    """
+
     type: Literal["smp"]
     architecture: str
     encoder_name: Optional[str] = "resnet50"
@@ -25,6 +49,21 @@ class SMPConfig(BaseModel):
 
 
 class HuggingFaceConfig(BaseModel):
+    """Configuration for HuggingFace segmentation models.
+
+    Attributes:
+        type (Literal["huggingface"]): Model type identifier.
+        model_name (str): HuggingFace model name or path.
+        num_labels (int, optional): Number of output classes. Defaults to None.
+        trust_remote_code (bool, optional): Allow remote code. Defaults to False.
+        weights_path (str | Path, optional): Path to weights file. Defaults to None.
+        device (str, optional): Device to use. Defaults to 'cpu'.
+        task (str, optional): Model task. Defaults to 'semantic_segmentation'.
+        return_processor (bool, optional): Return processor with model. Defaults to True.
+        config_overrides (dict, optional): Config attribute overrides. Defaults to empty dict.
+        processor_overrides (dict, optional): Processor attribute overrides. Defaults to empty dict.
+    """
+
     type: Literal["huggingface"]
     model_name: str
     num_labels: Optional[int] = None
@@ -40,6 +79,17 @@ class HuggingFaceConfig(BaseModel):
 
 
 class CustomConfig(BaseModel):
+    """Configuration for custom user-defined segmentation models.
+
+    Attributes:
+        type (Literal["custom"]): Model type identifier.
+        model_class (str | Callable[..., Any]): Model class or factory function.
+        model_args (list, optional): Positional arguments for model initialization. Defaults to empty list.
+        model_kwargs (dict, optional): Keyword arguments for model initialization. Defaults to empty dict.
+        weights_path (str | Path, optional): Path to weights file. Defaults to None.
+        device (str, optional): Device to use. Defaults to 'cpu'.
+    """
+
     type: Literal["custom"]
     model_class: Union[str, Callable[..., Any]]
     model_args: Optional[list[Any]] = Field(default_factory=list)

--- a/segmentation_robustness_framework/loaders/models/custom_loader.py
+++ b/segmentation_robustness_framework/loaders/models/custom_loader.py
@@ -92,16 +92,16 @@ class CustomModelLoader(BaseModelLoader):
 
             if weight_type == "full":
                 model.load_state_dict(state_dict, strict=False)
-                logger.info(f"Loaded full weights into custom model from {weights_path}")
+                logger.info(f"Loaded full model weights into custom model from {weights_path}")
             elif weight_type == "encoder":
                 if hasattr(model, "encoder"):
                     encoder_state_dict = {
                         k.replace("encoder.", ""): v for k, v in state_dict.items() if k.startswith("encoder.")
                     }
                     model.encoder.load_state_dict(encoder_state_dict, strict=False)
-                    logger.info(f"Loaded encoder weights into custom model from {weights_path}")
+                    logger.info(f"Loaded encoder (backbone) weights into custom model from {weights_path}")
                 else:
-                    logger.warning("Model has no 'encoder' attribute, loading full weights")
+                    logger.warning("Model has no 'encoder' attribute, loading full model weights")
                     model.load_state_dict(state_dict, strict=False)
             else:
                 raise ValueError(f"Unknown weight_type: {weight_type}. No weights loaded.")

--- a/segmentation_robustness_framework/loaders/models/huggingface_loader.py
+++ b/segmentation_robustness_framework/loaders/models/huggingface_loader.py
@@ -19,7 +19,7 @@ class HuggingFaceModelLoader(BaseModelLoader):
         - `model_name` (str): HuggingFace model id or path (required).
         - `num_labels` (int): Number of output classes (optional).
         - `trust_remote_code` (bool): Allow loading custom code from model repo (optional).
-        - `task` (str): "semantic_segmentation", "instance_segmentation", etc. (default: "semantic_segmentation").
+        - `task` (str): "semantic_segmentation", "instance_segmentation", "panoptic_segmentation", "image_segmentation" (optional).
         - `return_processor` (bool): Whether to return processor along with model (default: True).
         - `config_overrides` (dict): Arbitrary config attributes to override (optional).
         - `processor_overrides` (dict): Arbitrary processor attributes to override (optional).
@@ -80,6 +80,7 @@ class HuggingFaceModelLoader(BaseModelLoader):
         Args:
             model_config (dict[str, Any]):
                 - `model_name` (str): Model name/path (required).
+                - `model_cls` (Callable): Model class to use (optional).
                 - `num_labels` (int): Number of classes (optional).
                 - `trust_remote_code` (bool): Trust remote code (optional).
                 - `task` (str): Model task (optional).
@@ -94,7 +95,8 @@ class HuggingFaceModelLoader(BaseModelLoader):
         try:
             transformers = self._import_transformers()
             model_name = model_config["model_name"]
-            task = model_config.get("task", "semantic_segmentation")
+            model_cls = model_config.get("model_cls", None)
+            task = model_config.get("task", None)
             return_processor = model_config.get("return_processor", True)
             trust_remote_code = model_config.get("trust_remote_code", False)
 
@@ -105,12 +107,19 @@ class HuggingFaceModelLoader(BaseModelLoader):
                 for k, v in model_config["config_overrides"].items():
                     setattr(config, k, v)
 
-            if task == "semantic_segmentation":
-                model_cls = transformers.AutoModelForSemanticSegmentation
-            elif task == "instance_segmentation":
-                model_cls = transformers.AutoModelForInstanceSegmentation
+            if model_cls is None:
+                if task == "semantic_segmentation":
+                    model_cls = transformers.AutoModelForSemanticSegmentation
+                elif task == "instance_segmentation":
+                    model_cls = transformers.AutoModelForInstanceSegmentation
+                elif task == "panoptic_segmentation":
+                    model_cls = transformers.AutoModelForPanopticSegmentation
+                elif task == "image_segmentation":
+                    model_cls = transformers.AutoModelForImageSegmentation
+                else:
+                    model_cls = transformers.AutoModel
             else:
-                model_cls = transformers.AutoModel
+                model_cls = getattr(transformers, model_cls)
 
             model = model_cls.from_pretrained(model_name, config=config, trust_remote_code=trust_remote_code)
             logger.info(f"Loaded HuggingFace model: {model_name} (task: {task})")

--- a/segmentation_robustness_framework/loaders/models/huggingface_loader.py
+++ b/segmentation_robustness_framework/loaders/models/huggingface_loader.py
@@ -165,9 +165,9 @@ class HuggingFaceModelLoader(BaseModelLoader):
                     missing = result.missing_keys
                     unexpected = result.unexpected_keys
                     if missing:
-                        logger.warning(f"Missing keys when loading weights: {missing}")
+                        logger.warning(f"Missing keys when loading full model weights: {missing}")
                     if unexpected:
-                        logger.warning(f"Unexpected keys when loading weights: {unexpected}")
+                        logger.warning(f"Unexpected keys when loading full model weights: {unexpected}")
                 logger.info(f"Loaded full model weights into HuggingFace model from {weights_path}")
             elif weight_type == "encoder":
                 encoder_state_dict = {
@@ -178,12 +178,14 @@ class HuggingFaceModelLoader(BaseModelLoader):
                     missing = result.missing_keys
                     unexpected = result.unexpected_keys
                     if missing:
-                        logger.warning(f"Misпsing keys when loading encoder weights: {missing}")
+                        logger.warning(f"Missing keys when loading encoder weights: {missing}")
                     if unexpected:
                         logger.warning(f"Unexpected keys when loading encoder weights: {unexpected}")
-                    logger.info("Loaded encoder (backbone) weights only.")
+                    logger.info(f"Loaded encoder (backbone) weights into HuggingFace model from {weights_path}")
                 else:
-                    logger.info("Loaded encoder weights (no missing/unexpected keys info available).")
+                    logger.info(
+                        f"Loaded encoder weights (no missing/unexpected keys info available) into HuggingFace model from {weights_path}"
+                    )
             else:
                 logger.warning(f"Unknown weight_type: {weight_type}. No weights loaded.")
             return model

--- a/segmentation_robustness_framework/loaders/models/smp_loader.py
+++ b/segmentation_robustness_framework/loaders/models/smp_loader.py
@@ -152,12 +152,16 @@ class SMPModelLoader(BaseModelLoader):
                 state_dict = checkpoint
 
             if weight_type == "full":
-                missing, unexpected = model.load_state_dict(state_dict, strict=False)
-                if missing:
-                    logger.warning(f"Missing keys when loading weights: {missing}")
-                if unexpected:
-                    logger.warning(f"Unexpected keys when loading weights: {unexpected}")
-                logger.info("Loaded full model weights.")
+                result = model.load_state_dict(state_dict, strict=False)
+                if hasattr(result, "missing_keys") and hasattr(result, "unexpected_keys"):
+                    missing = result.missing_keys
+                    unexpected = result.unexpected_keys
+
+                    if missing:
+                        logger.warning(f"Missing keys when loading full model weights: {missing}")
+                    if unexpected:
+                        logger.warning(f"Unexpected keys when loading full model weights: {unexpected}")
+                logger.info(f"Loaded full model weights into SMP model from {weights_path}")
             elif weight_type == "encoder":
                 encoder_state_dict = {
                     k.replace("encoder.", ""): v for k, v in state_dict.items() if k.startswith("encoder.")
@@ -172,9 +176,11 @@ class SMPModelLoader(BaseModelLoader):
                         logger.warning(f"Missing keys when loading encoder weights: {missing}")
                     if unexpected:
                         logger.warning(f"Unexpected keys when loading encoder weights: {unexpected}")
-                    logger.info("Loaded encoder (backbone) weights only.")
+                    logger.info(f"Loaded encoder (backbone) weights into SMP model from {weights_path}")
                 else:
-                    logger.info("Loaded encoder weights (no missing/unexpected keys info available).")
+                    logger.info(
+                        f"Loaded encoder weights (no missing/unexpected keys info available) into SMP model from {weights_path}"
+                    )
             else:
                 logger.warning(f"Unknown weight_type: {weight_type}. No weights loaded.")
             return model

--- a/segmentation_robustness_framework/loaders/models/torchvision_loader.py
+++ b/segmentation_robustness_framework/loaders/models/torchvision_loader.py
@@ -158,7 +158,7 @@ class TorchvisionModelLoader(BaseModelLoader):
                     logger.warning(f"Missing keys when loading weights: {missing}")
                 if unexpected:
                     logger.warning(f"Unexpected keys when loading weights: {unexpected}")
-                logger.info("Loaded full model weights.")
+                logger.info(f"Loaded full model weights into torchvision model from {weights_path}")
             elif weight_type == "encoder":
                 backbone_state_dict = {
                     k.replace("backbone.", ""): v for k, v in state_dict.items() if k.startswith("backbone.")
@@ -168,7 +168,7 @@ class TorchvisionModelLoader(BaseModelLoader):
                     logger.warning(f"Missing keys when loading encoder weights: {missing}")
                 if unexpected:
                     logger.warning(f"Unexpected keys when loading encoder weights: {unexpected}")
-                logger.info("Loaded encoder (backbone) weights only.")
+                logger.info(f"Loaded encoder (backbone) weights into torchvision model from {weights_path}")
             else:
                 logger.warning(f"Unknown weight_type: {weight_type}. No weights loaded.")
             return model

--- a/segmentation_robustness_framework/loaders/models/torchvision_loader.py
+++ b/segmentation_robustness_framework/loaders/models/torchvision_loader.py
@@ -85,8 +85,15 @@ class TorchvisionModelLoader(BaseModelLoader):
             elif isinstance(weights, str):
                 if weights_enum_cls is not None and hasattr(weights_enum_cls, weights):
                     weights = getattr(weights_enum_cls, weights)
-                elif weights == "DEFAULT" and weights_enum_cls is not None and hasattr(weights_enum_cls, "DEFAULT"):
+                elif (
+                    weights.lower() == "default"
+                    and weights_enum_cls is not None
+                    and hasattr(weights_enum_cls, "DEFAULT")
+                ):
                     weights = weights_enum_cls.DEFAULT
+                else:
+                    logger.error(f"Invalid weights: {weights}")
+                    raise ValueError(f"Invalid weights: {weights}")
 
             model = model_fn(weights=weights, num_classes=num_classes)
             logger.info(f"Loaded torchvision model: {name} with weights={weights}")

--- a/segmentation_robustness_framework/loaders/models/universal_loader.py
+++ b/segmentation_robustness_framework/loaders/models/universal_loader.py
@@ -59,6 +59,7 @@ class UniversalModelLoader:
         model_config: dict[str, Any],
         weights_path: Optional[str] = None,
         weight_type: str = "full",
+        adapter_cls: Optional[type] = None,
     ) -> nn.Module:
         """Load model using appropriate loader and wrap with the correct adapter.
 
@@ -71,6 +72,8 @@ class UniversalModelLoader:
             model_config (dict[str, Any]): Configuration for model loading
             weights_path (Optional[str]): Path to weights file (optional)
             weight_type (str): Type of weights to load ('full' or 'encoder').
+            adapter_cls (Optional[type]): Adapter class to wrap the model. If provided, this
+                adapter will be used instead of the default adapter for the model type.
 
         Returns:
             nn.Module: Loaded and adapted model.
@@ -106,7 +109,7 @@ class UniversalModelLoader:
 
         # Wrap with adapter if not already adapted
         if not isinstance(model, SegmentationModelProtocol):
-            AdapterCls = get_adapter(model_type)
+            AdapterCls = adapter_cls or get_adapter(model_type)
             model = AdapterCls(model)
             logger.info(f"Wrapped model with {AdapterCls.__name__} adapter for type '{model_type}'")
         else:

--- a/segmentation_robustness_framework/loaders/models/universal_loader.py
+++ b/segmentation_robustness_framework/loaders/models/universal_loader.py
@@ -51,7 +51,6 @@ class UniversalModelLoader:
             "huggingface": HuggingFaceModelLoader() if HUGGINGFACE_INSTALLED else None,
             "custom": CustomModelLoader(),
         }
-        self.custom_loader = CustomModelLoader()
 
     def load_model(
         self,
@@ -84,7 +83,7 @@ class UniversalModelLoader:
                 logger.error(f"Required dependencies for {model_type} not available")
                 raise ImportError(f"Required dependencies for {model_type} not available")
         elif model_type.startswith("custom_"):
-            loader = self.custom_loader
+            loader = self.loaders["custom"]
         else:
             logger.error(f"Unsupported model type: {model_type}")
             raise ValueError(f"Unsupported model type: {model_type}")

--- a/segmentation_robustness_framework/utils/loader_utils.py
+++ b/segmentation_robustness_framework/utils/loader_utils.py
@@ -3,7 +3,23 @@ from typing import Any, Callable
 
 
 def resolve_model_class(model_class: str) -> Callable[..., Any]:
-    """Resolve a class from a string"""
+    """Resolve a class or callable from a string path or return as-is.
+
+    If the input string contains a dot, it is interpreted as a module path and class name,
+    and the class is imported and returned. Otherwise, the input is returned as-is (assumed callable).
+
+    Args:
+        model_class (str): Dotted path to a class (e.g., 'module.submodule.ClassName') or a callable name.
+
+    Returns:
+        Callable[..., Any]: The resolved class or callable object.
+
+    Example:
+        ```python
+        MyClass = resolve_model_class("my_package.my_module.MyClass")
+        instance = MyClass()
+        ```
+    """
     if "." in model_class:
         module_name, class_name = model_class.rsplit(".", 1)
         module = importlib.import_module(module_name)

--- a/tests/loaders/test_torchvision_model_loader.py
+++ b/tests/loaders/test_torchvision_model_loader.py
@@ -209,10 +209,9 @@ def test_torchvision_loader_weights_default_fallback_branch(monkeypatch):
     monkeypatch.setitem(TorchvisionModelLoader.TORCHVISION_WEIGHTS_ENUMS, name, _NoDefault)
 
     loader = TorchvisionModelLoader()
-    cfg = {"name": name, "weights": "DEFAULT"}
-    loader.load_model(cfg)
-
-    assert fn.call_args.kwargs["weights"] == "DEFAULT"
+    cfg = {"name": name, "weights": "default"}
+    with pytest.raises(ValueError, match="Invalid weights: default"):
+        loader.load_model(cfg)
 
 
 class _DummyAuxModel(nn.Module):


### PR DESCRIPTION
1. Multiple custom segmentation models are now supported. You need to inherit a new adapter from `CustomAdapter` and register it with a name starting with `custom_` in lowercase. For example, `custom_seg_adapter`. Example code:

```python
import torch
import torch.nn as nn

from segmentation_robustness_framework.adapters.registry import register_adapter
from segmentation_robustness_framework.adapters import CustomAdapter


class SimpleSegmentationModel(nn.Module):
    """Simple custom segmentation model for demonstration."""
    
    def __init__(self, num_classes: int = 35):
        super().__init__()
        self.num_classes = num_classes
        
        self.encoder = nn.Sequential(
            nn.Conv2d(3, 64, kernel_size=3, padding=1),
            nn.ReLU(inplace=True),
            nn.Conv2d(64, 64, kernel_size=3, padding=1),
            nn.ReLU(inplace=True),
            nn.MaxPool2d(2, 2),
            
            nn.Conv2d(64, 128, kernel_size=3, padding=1),
            nn.ReLU(inplace=True),
            nn.Conv2d(128, 128, kernel_size=3, padding=1),
            nn.ReLU(inplace=True),
            nn.MaxPool2d(2, 2),
        )
        
        self.decoder = nn.Sequential(
            nn.ConvTranspose2d(128, 64, kernel_size=2, stride=2),
            nn.ReLU(inplace=True),
            nn.Conv2d(64, 64, kernel_size=3, padding=1),
            nn.ReLU(inplace=True),
            
            nn.ConvTranspose2d(64, 32, kernel_size=2, stride=2),
            nn.ReLU(inplace=True),
            nn.Conv2d(32, 32, kernel_size=3, padding=1),
            nn.ReLU(inplace=True),
            
            nn.Conv2d(32, num_classes, kernel_size=1),
        )
    
    def forward(self, x):
        x = self.encoder(x)
        x = self.decoder(x)
        return x

@register_adapter("custom_seg")
class CustomSegmentationAdapter(CustomAdapter):    
    def __init__(self, model: nn.Module, num_classes: int = 21):
        super().__init__(model, num_classes)
        self.model = model
        self.num_classes = num_classes
    
    def logits(self, x: torch.Tensor) -> torch.Tensor:
        return self.model(x)
    
    def predictions(self, x: torch.Tensor) -> torch.Tensor:
        logits = self.logits(x)
        return torch.argmax(logits, dim=1)

    def forward(self, x):
        return self.model(x)


loader = UniversalModelLoader()
model = loader.load_model(
    model_type="custom_seg",
    model_config={
        "model_class": SimpleSegmentationModel,
        "model_kwargs": {"num_classes": 21},
    }
)

device = "cuda" if torch.cuda.is_available() else "cpu"
model = model.to(device)
```

2. You can pass the adapter class directly to the `load_model` method of the `UniversalModelLoader` loader. In this case, you don't need to register the adapter. You just need to specify `model_type="custom"` and pass the adapter class. Example code:

```python
model = loader.load_model(
    model_type="custom",
    model_config={
        "model_class": SimpleSegmentationModel,
        "model_kwargs": {"num_classes": 21},
    },
    adapter_cls=CustomSegmentationAdapter
)
```

If the adapter class is specified, the model will be wrapped in it. That is, if the name of one adapter was specified, and a completely different class was passed, then the second one will be used, and the first one will be overwritten.

3. Now to use standard (already trained) model weights from torchvision, you can use the value `"default"` in any register (previously it was strictly uppercase `"DEFAULT"`).

4. Fixed a bug with loading encoder weights in SMP models

5. Fixed loading models from `transformers`. Before this, the set of models available for loading was limited.

   - Now the variety of tasks has been expanded (to the existing `semantic_segmentation` and `instance_segmentation`, `panoptic_segmentation`, `image_segmentation` have been added).
   - The ability to explicitly specify the class of the model to be loaded has been added. To do this, it is enough to pass the model name and class name in the config.
   - For standard loading of a model, you need to specify its name, task (optional) and other optional parameters.

6. Added the ability to load encoder weights into models from `transformers`. To do this, you need to specify `weight_type="encoder"` in the `load_weights` method.
