### PR TITLE
v0.2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ preprocess, target_preprocess = image_preprocessing.get_preprocessing_fn(
 )
 dataset = VOCSegmentation(
     split="val", 
-    root="./data/voc",
+    root="path/to/existing/VOCdevkit/VOC2012/",
     transform=preprocess,
     target_transform=target_preprocess
 )

--- a/docs/configuration_guide.md
+++ b/docs/configuration_guide.md
@@ -124,6 +124,42 @@ tpgd_config = TPGDConfig(
 
 ## Dataset Configurations
 
+### Dataset Path Handling
+
+The framework handles dataset paths differently based on the `download` parameter:
+
+#### When `download=True` (Default)
+The framework creates organized nested directory structures:
+- **VOC**: `root/voc/VOCdevkit/VOC2012/`
+- **ADE20K**: `root/ade20k/ADEChallengeData2016/`
+- **Stanford Background**: `root/stanford_background/stanford_background/`
+
+This ensures datasets are organized and don't conflict with each other.
+
+#### When `download=False`
+The framework uses the exact path specified by `root`:
+- Useful for pre-downloaded datasets
+- Must point to the exact dataset directory
+- No nested structure is created
+
+#### Example Usage
+
+```python
+# Automatic download with nested structure
+voc_config = VOCConfig(
+    type="voc",
+    root="./data",  # Will create ./data/voc/VOCdevkit/VOC2012/
+    download=True
+)
+
+# Use existing dataset at exact path
+voc_config = VOCConfig(
+    type="voc",
+    root="/path/to/existing/VOCdevkit/VOC2012/",  # Exact VOC2012 directory
+    download=False
+)
+```
+
 ### Supported Dataset Types
 
 1. **VOC** (Pascal VOC 2012)
@@ -148,6 +184,8 @@ voc_config = VOCConfig(
 
 **Parameters:**
 - `root` (str | Path): Path to VOC2012 directory
+  - When `download=True`: Dataset will be downloaded to `root/voc/VOCdevkit/VOC2012/`
+  - When `download=False`: Must point to exact VOC2012 directory location
 - `split` (str): Dataset split ("train", "val", "trainval")
 - `image_shape` (list[int]): Desired image shape [height, width]
 - `max_images` (int | None): Maximum number of images to process
@@ -193,6 +231,8 @@ ade20k_config = ADE20KConfig(
 
 **Parameters:**
 - `root` (str | Path): Path to ADE20K directory
+  - When `download=True`: Dataset will be downloaded to `root/ade20k/ADEChallengeData2016/`
+  - When `download=False`: Must point to exact ADEChallengeData2016 directory location
 - `split` (str): Dataset split ("train" or "val")
 - `image_shape` (list[int]): Desired image shape [height, width]
 - `max_images` (int | None): Maximum number of images to process
@@ -213,6 +253,8 @@ stanford_config = StanfordBackgroundConfig(
 
 **Parameters:**
 - `root` (str | Path): Path to Stanford Background directory
+  - When `download=True`: Dataset will be downloaded to `root/stanford_background/stanford_background/`
+  - When `download=False`: Must point to exact stanford_background directory location
 - `split` (str): Dataset split (only "train" available)
 - `image_shape` (list[int]): Desired image shape [height, width]
 - `max_images` (int | None): Maximum number of images to process

--- a/docs/custom_datasets_guide.md
+++ b/docs/custom_datasets_guide.md
@@ -17,6 +17,13 @@ Your custom dataset should:
    - `mask` is a tensor of shape `[H, W]` with class indices
 3. Set a `name` attribute for color mapping (if needed)
 
+### Path Handling
+
+Custom datasets should handle paths consistently with the framework's approach:
+- Use the exact `root` path provided by the user
+- Don't create nested directory structures unless specifically needed
+- Document the expected directory structure clearly
+
 ### Example: Medical Dataset
 
 ```python

--- a/docs/index.md
+++ b/docs/index.md
@@ -78,6 +78,9 @@ results = pipeline.run()
 ### 📊 Dataset Support
 - **Built-in Datasets**: VOC, ADE20K, Cityscapes, Stanford Background
   - *Note: Cityscapes cannot be downloaded automatically due to required authorization. You must register and download it manually from https://www.cityscapes-dataset.com/.*
+- **Smart Path Handling**: 
+  - `download=True`: Creates organized nested directory structures
+  - `download=False`: Uses exact user-specified paths for pre-downloaded datasets
 - **Custom Datasets**: Simple integration of your own datasets
 - **Automatic Download**: Built-in dataset downloading and preprocessing (except Cityscapes)
 

--- a/docs/practical_example.md
+++ b/docs/practical_example.md
@@ -197,7 +197,7 @@ def run_medical_robustness_evaluation():
     
     # 3. Load dataset
     dataset = MedicalLungsDataset(
-        root="data/medical_lungs",
+        root="data/medical_lungs",  # Exact path to dataset directory
         split="val",
         transform=preprocess,
         target_transform=target_preprocess
@@ -319,7 +319,7 @@ def validate_custom_implementation():
     """Validate that custom dataset and attack work correctly."""
     
     # Test dataset
-    dataset = MedicalLungsDataset(root="data/medical_lungs", split="val")
+    dataset = MedicalLungsDataset(root="data/medical_lungs", split="val")  # Exact path
     print(f"Dataset loaded: {len(dataset)} samples")
     
     # Test single sample

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -71,7 +71,7 @@ dataset = VOCSegmentation(
     root="./data",  # Dataset will be downloaded here
     transform=preprocess,           # Image preprocessing
     target_transform=target_preprocess,  # Mask preprocessing
-    download=True
+    download=True  # Automatically download and extract to ./data/voc/
 )
 
 print(f"✅ Dataset loaded with {len(dataset)} samples")
@@ -267,7 +267,7 @@ dataset = ADE20K(
     root="./data",
     transform=preprocess,
     target_transform=target_preprocess,
-    download=True,
+    download=True,  # Automatically download and extract to ./data/ade20k/ADEChallengeData2016/
 )
 
 # Stanford Background dataset
@@ -279,9 +279,36 @@ preprocess, target_preprocess = image_preprocessing.get_preprocessing_fn(
 )
 
 dataset = StanfordBackground(
-    root="./data/stanford_background",
+    root="./data",
     transform=preprocess,
-    target_transform=target_preprocess
+    target_transform=target_preprocess,
+    download=True  # Automatically download and extract to ./data/stanford_background/stanford_background/
+)
+```
+
+### Dataset Path Logic
+
+The framework handles dataset paths differently based on the `download` parameter:
+
+**When `download=True` (default):**
+- Creates nested directory structure for organization
+- VOC: `root/voc/VOCdevkit/VOC2012/`
+- ADE20K: `root/ade20k/ADEChallengeData2016/`
+- Stanford Background: `root/stanford_background/stanford_background/`
+
+**When `download=False`:**
+- Uses the exact path specified by `root`
+- Useful when you have pre-downloaded datasets
+- Example: `root="/path/to/existing/voc/dataset"`
+
+```python
+# Using pre-downloaded dataset
+dataset = VOCSegmentation(
+    split="val",
+    root="/path/to/existing/voc/dataset",  # Exact path to dataset
+    transform=preprocess,
+    target_transform=target_preprocess,
+    download=False  # Use existing dataset at exact path
 )
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "segmentation-robustness-framework"
-version = "0.2.0"
+version = "0.2.1"
 description = "Segmentation Robustness Framework - a powerful toolkit for evaluating the robustness of semantic segmentation models against adversarial attacks."
 license = "MIT"
 authors = ["Egor Vorobyev <voro6yov.egor@gmail.com>"]

--- a/segmentation_robustness_framework/__version__.py
+++ b/segmentation_robustness_framework/__version__.py
@@ -1,3 +1,3 @@
-VERSION = (0, 2, 0)
+VERSION = (0, 2, 1)
 
 __version__ = ".".join(map(str, VERSION))

--- a/segmentation_robustness_framework/datasets/ade20k.py
+++ b/segmentation_robustness_framework/datasets/ade20k.py
@@ -20,8 +20,12 @@ class ADE20K(Dataset):
     **Setup Instructions:**
 
     The dataset will be automatically downloaded and extracted if not present.
-    If `root` is provided, the dataset will be stored at `root/ade20k/ADEChallengeData2016/`.
-    If `root` is `None`, the dataset will be cached in the default cache directory.
+    When `download=True` (default):
+        - If `root` is provided, the dataset will be stored at `root/ade20k/ADEChallengeData2016/`.
+        - If `root` is `None`, the dataset will be cached in the default cache directory.
+    When `download=False`:
+        - The dataset must be present at the exact path specified by `root`.
+        - If `root` is `None`, the dataset will be looked for in the default cache directory.
 
     **Supported Splits:**
     - `train`: Training images (~20,000 samples)
@@ -67,8 +71,11 @@ class ADE20K(Dataset):
         """
         from segmentation_robustness_framework.utils.dataset_utils import get_cache_dir
 
-        root_path = Path(root) / "ade20k" if root is not None else get_cache_dir("ade20k")
-        dataset_path = root_path / "ADEChallengeData2016"
+        if download:
+            root_path = Path(root) / "ade20k" if root is not None else get_cache_dir("ade20k")
+            dataset_path = root_path / "ADEChallengeData2016"
+        else:
+            dataset_path = Path(root) if root is not None else get_cache_dir("ade20k")
 
         if not dataset_path.exists():
             if download:

--- a/segmentation_robustness_framework/datasets/stanford_background.py
+++ b/segmentation_robustness_framework/datasets/stanford_background.py
@@ -20,8 +20,12 @@ class StanfordBackground(Dataset):
     **Setup Instructions:**
 
     The dataset will be automatically downloaded and extracted if not present.
-    If `root` is provided, the dataset will be stored at `root/stanford_background/stanford_background/`.
-    If `root` is `None`, the dataset will be cached in the default cache directory.
+    When `download=True` (default):
+        - If `root` is provided, the dataset will be stored at `root/stanford_background/stanford_background/`.
+        - If `root` is `None`, the dataset will be cached in the default cache directory.
+    When `download=False`:
+        - The dataset must be present at the exact path specified by `root`.
+        - If `root` is `None`, the dataset will be looked for in the default cache directory.
 
     **Dataset Structure:**
     - `images/`: Input RGB images
@@ -62,8 +66,11 @@ class StanfordBackground(Dataset):
         """
         from segmentation_robustness_framework.utils.dataset_utils import get_cache_dir
 
-        root_path = Path(root) / "stanford_background" if root is not None else get_cache_dir("stanford_background")
-        dataset_path = root_path / "stanford_background"
+        if download:
+            root_path = Path(root) / "stanford_background" if root is not None else get_cache_dir("stanford_background")
+            dataset_path = root_path / "stanford_background"
+        else:
+            dataset_path = Path(root) if root is not None else get_cache_dir("stanford_background")
 
         if not dataset_path.exists():
             if download:

--- a/segmentation_robustness_framework/datasets/voc.py
+++ b/segmentation_robustness_framework/datasets/voc.py
@@ -20,8 +20,12 @@ class VOCSegmentation(Dataset):
     **Setup Instructions:**
 
     The dataset will be automatically downloaded and extracted if not present.
-    If `root` is provided, the dataset will be stored at `root/voc/VOCdevkit/VOC2012/`.
-    If `root` is `None`, the dataset will be cached in the default cache directory.
+    When `download=True` (default):
+        - If `root` is provided, the dataset will be stored at `root/voc/VOCdevkit/VOC2012/`.
+        - If `root` is `None`, the dataset will be cached in the default cache directory.
+    When `download=False`:
+        - The dataset must be present at the exact path specified by `root`.
+        - If `root` is `None`, the dataset will be looked for in the default cache directory.
 
     **Supported Splits:**
     - `train`: Training images (1,464 samples)
@@ -68,8 +72,11 @@ class VOCSegmentation(Dataset):
         """
         from segmentation_robustness_framework.utils.dataset_utils import get_cache_dir
 
-        root_path = Path(root) / "voc" if root is not None else get_cache_dir("voc")
-        dataset_root = root_path / "VOCdevkit" / "VOC2012"
+        if download:
+            root_path = Path(root) / "voc" if root is not None else get_cache_dir("voc")
+            dataset_root = root_path / "VOCdevkit" / "VOC2012"
+        else:
+            dataset_root = Path(root) if root is not None else get_cache_dir("voc")
 
         if not dataset_root.exists():
             if download:

--- a/segmentation_robustness_framework/utils/image_preprocessing.py
+++ b/segmentation_robustness_framework/utils/image_preprocessing.py
@@ -69,18 +69,18 @@ def prepare_inputs(sample, maybe_bundle, device="cuda"):
     return {"pixel_values": sample.to(device)}
 
 
-def get_preprocessing_fn(image_shape: list[int], dataset_name: Optional[str] = None) -> Callable:
+def get_preprocessing_fn(image_shape: list[int] | tuple[int, int], dataset_name: Optional[str] = None) -> Callable:
     """Get preprocessing functions for images and masks.
 
     Args:
-        image_shape (list[int]): Desired image shape [height, width].
+        image_shape (list[int] | tuple[int, int]): Desired image shape [height, width].
         dataset_name (Optional[str]): Name of the dataset for dataset-specific mask processing.
 
     Returns:
         Callable: Tuple of (image_preprocess, target_preprocess) functions.
     """
-    if not isinstance(image_shape, list):
-        raise TypeError(f"Expected a list [height, width], but got {image_shape}")
+    if not isinstance(image_shape, (list, tuple)):
+        raise TypeError(f"Expected a list or tuple [height, width], but got {image_shape}")
 
     if len(image_shape) == 2:
         w, h = image_shape[0], image_shape[1]


### PR DESCRIPTION
1. The logic of the paths specified in the dataset has been changed. Now the structure of nested directories is created only when `download=True`. In the case of `download=False`, you need to specify the exact and full path directly to the directory with images. The changes affected three datasets: VOC, ADE20K, StanfordBackground.
2. The `get_preprocessing_gn()` function can now accept a tuple of two numbers as `image_shape`.